### PR TITLE
fix: only sync once during login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Resolved an issue with `AuthContext` that was causing logged in users to be stuck at "Loading..." page
+- Resolved an issue with `AuthContext` that was repeatedly syncing user information with the server
 
 ## [0.1.1] - 12-11-2025
 


### PR DESCRIPTION
## Description
Resolved issue where `auth/verify` endpoint was repeatedly being called

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🎨 UI/Style
- [ ] ♻️ Refactor
- [ ] 🔧 Config/Build

## Related Issues
Closes #

## Changes
- Syncing endpoint only called once upon initial login

## Testing
- [x] Manual testing completed
- [ ] Tests pass