### PR TITLE
fix: change payload property name to match backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1] - 24-12-2025
+
+### Changes
+- Changed `isSettled` to `settled` for `ExpenseSplitResponse`, to match Jackson serialization
+
 ## [0.4.0] - 24-12-2025
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "howmuchah",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/expenses/ExpenseDetailModal.tsx
+++ b/src/components/expenses/ExpenseDetailModal.tsx
@@ -64,7 +64,7 @@ function ExpenseDetailModal({ open, onClose, expenseId, groupId }: ExpenseDetail
   };
 
   // Check if expense is fully settled
-  const isSettled = expense?.splits.every(split => split.isSettled) ?? false;
+  const isSettled = expense?.splits.every(split => split.settled) ?? false;
 
   if (isLoading || !expense) {
     return (
@@ -148,11 +148,11 @@ function ExpenseDetailModal({ open, onClose, expenseId, groupId }: ExpenseDetail
                       <p className="text-xs text-muted-foreground break-all">{split.user.email}</p>
                     </div>
                     <div className="text-right shrink-0">
-                      <p className={`font-semibold ${!split.isSettled ? 'text-destructive' : 'text-green-600'}`}>
+                      <p className={`font-semibold ${!split.settled ? 'text-destructive' : 'text-green-600'}`}>
                         {formatCurrency(split.amountOwed, expense.currency)}
                       </p>
                       <p className="text-xs text-muted-foreground whitespace-nowrap">
-                        {split.isSettled ? 'Settled' : 'Pending'}
+                        {split.settled ? 'Settled' : 'Pending'}
                       </p>
                     </div>
                   </div>

--- a/src/services/expenses/types.ts
+++ b/src/services/expenses/types.ts
@@ -33,7 +33,7 @@ export interface ExpenseSplitResponse {
   id: string;
   user: UserSummary;
   amountOwed: number;
-  isSettled: boolean;
+  settled: boolean;
 }
 
 export interface ExpenseDetailResponse {


### PR DESCRIPTION
## Description
<!-- What does this PR do? -->
Changes the JSON parameter name to match what is given from Spring Boot.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🎨 UI/Style
- [ ] ♻️ Refactor
- [ ] 🔧 Config/Build

## Related Issues
Closes #

## Changes
- Changed `isSettled` to `settled` for `ExpenseSplitResponse`, to match Jackson serialization

## Testing
- [x] Manual testing completed
- [ ] Tests pass